### PR TITLE
Make the fork-safety test build on all platforms

### DIFF
--- a/tests/fork_safety/main.cpp
+++ b/tests/fork_safety/main.cpp
@@ -1,3 +1,18 @@
+#include <catch2/catch_all.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#ifdef _WIN32
+
+// Windows has no fork(); multiprocessing uses spawn, so the inherited-mutex
+// hazard this test guards against cannot occur. Keep a placeholder so the
+// suite is uniform across platforms.
+TEST_CASE("fork safety (POSIX only)")
+{
+    SKIP("fork() is unavailable on Windows; multiprocessing uses spawn");
+}
+
+#else
+
 #include <atomic>
 #include <cstdlib>
 #include <string>
@@ -6,9 +21,6 @@
 
 #include <sys/wait.h>
 #include <unistd.h>
-
-#include <catch2/catch_all.hpp>
-#include <catch2/catch_test_macros.hpp>
 
 #include "../common.hpp"
 #include "sciqlop_cache/sciqlop_cache.hpp"
@@ -65,3 +77,5 @@ TEST_CASE("forked child can use the inherited cache without deadlocking")
     for (auto& t : hammer)
         t.join();
 }
+
+#endif // _WIN32


### PR DESCRIPTION
Follow-up to #5.

`tests/fork_safety/main.cpp` used `fork()`, `<sys/wait.h>`, `<unistd.h>` and `SIGKILL` unconditionally. The C++ tests are currently only compiled on Linux (the coverage job) and in local dev builds, so nothing is failing today — but configuring with `-Dwith_tests=true` on Windows would fail to compile.

Guard the POSIX test under `#ifndef _WIN32`; on Windows compile a skipped placeholder. Windows has no `fork()` and `multiprocessing` uses spawn, so the inherited-mutex hazard the test guards against cannot occur there.

Test-only change — no library/wheel impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)